### PR TITLE
Faster construction and isomorphism testing

### DIFF
--- a/src/all-fusion-systems.m
+++ b/src/all-fusion-systems.m
@@ -1,3 +1,7 @@
+
+
+
+
 // Puts the essentials in order according to Group Name
 procedure OrderEssentials(S, ~Autos)
     p := FactoredOrder(S)[1][1];
@@ -14,6 +18,8 @@ procedure OrderEssentials(S, ~Autos)
         Reverse(~Autos); 
     end if; 
 end procedure;
+
+
 
 
 intrinsic AllFusionSystems(S::Grp:SaveEach:=false,Printing:=false,OutFSOrders:=[],OpTriv:=true,pPerfect:= true)-> SeqEnum

--- a/src/general-fusion-system.m
+++ b/src/general-fusion-system.m
@@ -1,5 +1,7 @@
 // General functions dealing with fusion systems
 
+import "properties-fusion-systems.m" : MakeAllSubgroups;
+
 
 intrinsic 'eq'(F1::FusionSystem, F2::FusionSystem) -> Bool
     {checks if two fusion systems are equal}
@@ -128,7 +130,7 @@ intrinsic IsIsomorphic (F1::FusionSystem,F2::FusionSystem)->Bool{}
     ImAutEssentials[zz]:=ImAutEssentialsCalc;
      
     end for;
-
+    MakeAllSubgroups(F2);
     for XXct in [1..#ImEssentials] do XX:=ImEssentials[XXct];
         for ii in [1..#XX] do e:= XX[ii]; if e in F2`subgroups then continue; end if;
                 jj:= IdentifyBClass(F2,e);

--- a/src/generating-fusion-systems.m
+++ b/src/generating-fusion-systems.m
@@ -229,81 +229,43 @@ intrinsic CreateFusionSystem(Autos::SeqEnum) -> FusionSystem
     ////////////////////////////////////////////////// 
     InnFp:=sub<AutSp|{map(g): g in Generators(InnS1)}>;
     AutFSp:=sub<AutSp|{map(g): g in Generators(Autos[1])}>;  
-      C:=Random(Complements(AutFSp,InnFp));  
+    C:=Random(Complements(AutFSp,InnFp));  
     C:=SubInvMap(map,AutS1,C); 
     if #C gt 1 then 
-         Ba, phi1:= Holomorph(GrpFP,S1,C); 
-         Sa:= sub<Ba|[phi1(x):x in Generators(S1)]>; 
-         phi2:=iso<Sa->S1|[<phi1(S1.i),S1.i>: i in [1..#Generators(Sa)]]>; 
-         L:= sub<Ba|{x: x in Generators(Ba)| not x in Sa}>;  
-         theta, Bb:= CosetAction(Ba,L); B,thetaB:= PCGroup(Bb);
+        Ba, phi1:= Holomorph(GrpFP,S1,C); 
+        Sa:= sub<Ba|[phi1(x):x in Generators(S1)]>; 
+        phi2:=iso<Sa->S1|[<phi1(S1.i),S1.i>: i in [1..#Generators(Sa)]]>; 
+        L:= sub<Ba|{x: x in Generators(Ba)| not x in Sa}>;  
+        theta, Bb:= CosetAction(Ba,L); 
+        B,thetaB:= PCGroup(Bb);
         phiB:= phi1*theta*thetaB; 
         S:= sub<B|[phiB(x):x in Setseq(Generators(S1))]>;
         InvphiB := Inverse(thetaB)*Inverse(theta)*phi2;
-       
-         else
-         B:= S1; 
-         B,phiB:= PCGroup(B); InvphiB := Inverse(phiB);
+    else
+        B:= S1; 
+        B,phiB:= PCGroup(B); InvphiB := Inverse(phiB);
     end if;
     S:= phiB(S1); 
     F`group:= S;    
     F`borel:= B;  
-      
-      MakeAutos(S);
-      F`essentialautos:= [];
-       F`essentials:=[phiB(Group(Autos[i])):i in [1..#Autos]];
-     for x in F`essentials do MakeAutos(x); end for;
-        for ix in [1..#Autos] do
-            x:= F`essentials[ix];  
-       XX:=sub<x`autogrp|[InvphiB*w*phiB:w in Generators(Autos[ix])]>; 
-        
-        F`essentialautos:= Append( F`essentialautos,XX); 
-        end for;
-      
-    ////////////////////////
-    ////The essentials and essential autos have been assigned. 
-    ////We treat S as an essential. 
-    ////////////////////////
 
-    ////////////////////////
-    //////We now create all the subgroups of the fusion system up to B conjugacy 
-    //////Perhaps this could be done later.
-    //////////////////////
-    subsBS:=Subgroups(B: OrderDividing:=#S);
-
-    ////////////////////////
-    //////Perhaps the algorithm doesn't select our essentials as representatives of 
-    /////their B-conjugacy class. We correct this
-    //////////////////////
-
-    //
-    F`subgroups:=[x`subgroup:x in subsBS];
-    for ii := 1 to #F`essentials do
-        X:= F`essentials[ii];
-        if X in F`subgroups eq false then 
-            for jj in [1..#F`subgroups] do
-                w:= F`subgroups[jj];
-                if IsConjugate(B,w , X) then   F`subgroups[jj]:= X; break jj; end if;
-            end for;
-        end if;
+    F`essentialautos:= [];
+    F`essentials:=[phiB(Group(Autos[i])):i in [1..#Autos]];
+    for x in F`essentials do 
+        MakeAutos(x); 
     end for;
-    //////////////////////////////////////////
-    ///////We initialise F`AutF and place in the automorphism of essentials 
-    ///////////////////////////// 
-    F`AutF:= AssociativeArray(F`subgroups);
 
+    for ix in [1..#Autos] do
+        x:= F`essentials[ix];  
+        XX:=sub<x`autogrp|[InvphiB*w*phiB:w in Generators(Autos[ix])]>; 
+        F`essentialautos:= Append(F`essentialautos,XX); 
+    end for;
+    
+    F`AutF:= AssociativeArray();
     for x in F`essentials do 
        F`AutF[x] := F`essentialautos[Index(F`essentials,x)]; 
     end for; 
 
-    //We make all autos of S-centric subgroups. Perhaps this is a place we can save
-    //memory
-    for ii in [1..#F`subgroups] do 
-        x:= F`subgroups[ii]; 
-        if IsSCentric(S,x) then 
-            MakeAutos(x);
-        end if; 
-    end for;
     return F;
 end intrinsic;
 

--- a/src/group-properties-fusion-system.m
+++ b/src/group-properties-fusion-system.m
@@ -1,10 +1,14 @@
 // Functions related to properties of a subgroup within the fusion system
+import "properties-fusion-systems.m" : MakeAllSubgroups;
+
+
 
 
 intrinsic IdentifyBClass(F::FusionSystem,P::Grp)->RngIntElt,GrpElt
     {Identifies a AutFS-conjugacy class}
-     
-     SS:= F`subgroups; B:= F`borel;
+     MakeAllSubgroups(F);
+     SS:= F`subgroups; 
+     B:= F`borel;
      for ii := 1 to #SS do 
         aa,bbb:=IsConjugate(B,P,SS[ii]);
         if aa then return ii,bbb; end if; 
@@ -27,6 +31,7 @@ intrinsic IdentifyFOrbit(F::FusionSystem,P::Grp)->SetEnum
       if assigned(F`fusiongraph) eq false then 
           F`fusiongraph, F`maps:= FusionGraph(F); 
       end if;   F`classes:= ConnectedComponents(F`fusiongraph);
+        MakeAllSubgroups(F);
       ii:= Index(F`subgroups,P);
                 for C in F`classes do
                     if ii in C then D:= C; break; end if;
@@ -38,6 +43,7 @@ end intrinsic;
 
 intrinsic ConjugacyClass(F::FusionSystem,P:Grp)-> SetEnum
    {Determines the F-conjugacy class of a subgroup}
+    MakeAllSubgroups(F);
    SS:= F`subgroups;S:= F`group;
        if assigned(F`fusiongraph) eq false then 
            F`fusiongraph,F`maps:= FusionGraph(F);  
@@ -58,7 +64,7 @@ end intrinsic;
 
 intrinsic IsConjugate(F::FusionSystem, P::Grp,Q::Grp)->Bool,Map 
    {returns a homomorphism and true if the groups are F-conjugate}
-
+    MakeAllSubgroups(F);
    SS:= F`subgroups; S:= F`group; B:= F`borel; 
    if assigned(F`fusiongraph) eq false then 
        F`fusiongraph,F`maps:= FusionGraph(F);  
@@ -154,7 +160,7 @@ end intrinsic;
 
 intrinsic IsCentric(F::FusionSystem,P::Grp)->Bool
    {Returns true if P is F-centric}
-
+    MakeAllSubgroups(F);
    SS:= F`subgroups; S:= F`group; B:= F`borel; 
    if assigned(F`fusiongraph) eq false then 
        F`fusiongraph,F`maps:= FusionGraph(F); 
@@ -176,6 +182,7 @@ intrinsic IsCentric(F::FusionSystem,P::Grp)->Bool
 
 intrinsic IsFullyNormalized(F::FusionSystem, P::Grp)->Bool
    {Is the subgroup full F-Normalized}
+    MakeAllSubgroups(F);
    SS:= F`subgroups; S:= F`group; B:= F`borel; 
    if assigned(F`fusiongraph) eq false then 
    F`fusiongraph,F`maps:= FusionGraph(F);  
@@ -202,6 +209,7 @@ end intrinsic;
 
 
 intrinsic IsFullyCentralized(F::FusionSystem, P::Grp)->Bool{Is the subgroup full F-Centralized}
+ MakeAllSubgroups(F);
    SS:= F`subgroups; S:= F`group; B:= F`borel; 
    if assigned(F`fusiongraph) eq false then F`fusiongraph,F`maps:=FusionGraph(F);  
    end if;
@@ -274,7 +282,7 @@ intrinsic SurjectivityProperty(F::FusionSystem,P::Grp:saturationtest)->Bool, Boo
     return F`saturated, F`saturated; end if;
 
     require IsCentric(F,P):"subgroup not F-centric";
-
+     MakeAllSubgroups(F);
     SS:= F`subgroups; 
     S:= F`group; 
     B:= F`borel; 
@@ -369,6 +377,7 @@ end intrinsic;
 
 intrinsic AutomorphismGroup(F::FusionSystem,P::Grp)-> GrpAuto
     {Calculates the automorphism group of P}
+     MakeAllSubgroups(F);
     SS:= F`subgroups;
     Essentials:= F`essentials;
     B:= F`borel;

--- a/src/properties-fusion-systems.m
+++ b/src/properties-fusion-systems.m
@@ -1,6 +1,32 @@
 // Functions that determine properties of a given fusion system
 
 
+
+
+procedure MakeAllSubgroups(F)
+    // Assigns all subgroups of a fusion system
+    if not assigned(F`subgroups) then
+        B := F`borel;
+        subsBS:=Subgroups(B: OrderDividing:=#F`group);
+        F`subgroups:=[x`subgroup:x in subsBS];
+        // The following code makes sure our essentials are the representatives in F`subgroups
+        for ii := 1 to #F`essentials do
+            X:= F`essentials[ii];
+            if X in F`subgroups eq false then 
+                for jj in [1..#F`subgroups] do
+                    w:= F`subgroups[jj];
+                    if IsConjugate(B,w , X) then   F`subgroups[jj]:= X; break jj; end if;
+                end for;
+            end if;
+        end for;
+    end if;
+
+
+end procedure;
+
+
+
+
 // Duplicated in the original file
 intrinsic AutFCore(Es::SeqEnum,AutE::SeqEnum)->Grp,GrpAuto
     {calculates F core and action on it}
@@ -111,6 +137,7 @@ intrinsic FusionGraph(F::FusionSystem)->GrphUnd, Assoc
 if assigned(F`fusiongraph)  then return F`fusiongraph,F`maps; end if;
 
 Essentials := F`essentials;
+MakeAllSubgroups(F);
 SS:= F`subgroups;
 S:= F`group;
 B:=F`borel;
@@ -171,6 +198,7 @@ intrinsic FusionGraphSCentrics(F::FusionSystem)->GrphUnd, Assoc
 
     S:= F`group;
     B:=F`borel;
+    MakeAllSubgroups(F);
     SS:=  F`subgroups;
     Gamma := Graph<#SS|>;
     SSxSS:= [[n,m]:n in [1..#SS],m in [1..#SS]];
@@ -251,6 +279,7 @@ intrinsic MakeAllAutFCentric(FF::FusionSystem:saturationtest)->Assoc, Bool
     {Makes all AutF for centric subgroups unless parameter saturated test eq true in which case it stops early when the system is not saturated .}
 
     ZZ:=Integers();
+    MakeAllSubgroups(FF);
     SS:= FF`subgroups;
     S:= FF`group; 
     B:= FF`borel; 
@@ -397,7 +426,7 @@ intrinsic IsSaturated(F::FusionSystem)-> Bool
     {Determines if F is saturated}
 
     if assigned(F`saturated) then return F`saturated; end if;
-     
+    MakeAllSubgroups(F);
     SS:= F`subgroups; 
     S:= F`group; 
     B:= F`borel; 

--- a/tests/test-record-isomorphism.m
+++ b/tests/test-record-isomorphism.m
@@ -1,0 +1,31 @@
+// Test that the results of the isomorphism test via records is the same
+// as the IsIsomorphism fusion system output
+
+flag := true;
+FS := [SmallFusionSystemRecord(5^5, i) : i in [1..NumberSmallFusionSystems(5^5)]];
+
+for i in [1..#FS - 1] do 
+	R := FS[i];
+	F := LoadFusionSystem(R);
+	if not IsomorphismTest(R,R) then 
+		flag := false;
+		print "Failed: Record is not isomorphic to itself \n";
+	end if;
+	if not (IsIsomorphic(F, F) eq IsomorphismTest(R,R)) then 
+		flag := false;
+		print "Failed: Testing isomorphic to self failed \n";
+		printf "IsomorphismTest(R,R) : %o \n", IsomorphismTest(R,R);
+		printf "IsIsomorphic(F,F) : %o \n", IsIsomorphic(F,F);
+	end if;
+	for j in [i+1..#FS] do 
+		RR := FS[j];
+		FF := LoadFusionSystem(RR);
+		if not (IsIsomorphic(F, FF) eq IsomorphismTest(R,RR)) then
+			flag := false;
+			print "Failed: IsIsomorphism is not equal to IsomorphismTest \n";
+		end if;
+	end for;
+	printf "Test %o passed \n", i;
+end for;
+
+print flag;


### PR DESCRIPTION
Removed constructing all subgroups when creating a fusion system, instead called as needed.

Added IsIsomorphic(R_1, R_2) for records, in theory should be faster proving that two fusion systems are not isomorphic than IsIsomorphic(F_1, F_2)

Added function for checking if there are duplicates, I realised that the isomorphism test is broken so some of the fusion systems I've generated earlier might be duplicates